### PR TITLE
feat: rust-analyzer config, extra logs in sync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "rust-analyzer.server.extraEnv": {
+      "AR": "/opt/homebrew/opt/llvm/bin/llvm-ar",
+      "CC": "/opt/homebrew/opt/llvm/bin/clang"
+  },
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+  "rust-analyzer.checkOnSave.allTargets": false
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+build:
+```
+cargo clean                       
+wasm-pack build --target bundler
+```
+
+
+run tests:
+```
+wasm-pack test --headless --chrome
+```
+
+
+
 <div align="center">
 
   <h1><code>wasm-pack-template</code></h1>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,12 +100,14 @@ impl WalletWrapper {
             .await
             .map_err(|e| format!("{:?}", e))?;
 
+        console::log_1(&"after sync".into());
+
         wallet
             .borrow_mut()
             .apply_update(update)
             .map_err(|e| format!("{:?}", e))?;
 
-        console::log_1(&"after sync".into());
+        console::log_1(&"after apply".into());
 
         Ok(())
     }


### PR DESCRIPTION
this config is to get rust-analyzer to work (vscode or cursor)

Also, I'm getting an error when calling .sync (from my example app):
ERROR
unreachable
RuntimeError: unreachable
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[802]:0xf93fd
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[1823]:0x13aea7
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[116]:0x5a3fb
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[564]:0xd9e44
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[2200]:0x14df0f
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[2183]:0x14dcff
    at http://localhost:8080/82824b88d549bf172bf7.module.wasm:wasm-function[2272]:0x14f08c
    at __wbg_adapter_26 (webpack://example-bdk-wasm/../bdk-wasm/pkg/bdk_wasm_bg.js?:262:10)
    at real (webpack://example-bdk-wasm/../bdk-wasm/pkg/bdk_wasm_bg.js?:247:20)

my browser console outputs:
Hello, bdk-wasm!
index.js:26 Starting wallet sync...
82824b88d549bf172bf7.module.wasm:0x1524c5 before sync
82824b88d549bf172bf7.module.wasm:0x1524c5 
Scanning keychain [External]
82824b88d549bf172bf7.module.wasm:0x1524c5  0  
82824b88d549bf172bf7.module.wasm:0x1524c5 
Scanning keychain [Internal]
82824b88d549bf172bf7.module.wasm:0x1524c5  0  
82824b88d549bf172bf7.module.wasm:0x1524c5 after sync

with the extra log I added this confirms that the error happens on the apply
```
        wallet
            .borrow_mut()
            .apply_update(update)
            .map_err(|e| format!("{:?}", e))?;
            ```